### PR TITLE
advanced should be flex-column

### DIFF
--- a/_sass/components/poll.scss
+++ b/_sass/components/poll.scss
@@ -33,5 +33,6 @@
 
 	&--advanced {
 		display: flex;
+		flex-direction: column;
 	}
 }


### PR DESCRIPTION
why? Otherwise browsers will put more things (there's just one element now) next to eachother, but we want them underneath eachother.

Will also make the experience look better if details isn't supported (although gin-fizz/pollistics#92 introduces a polyfill)