### PR TITLE
add jekyll-autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 source "https://rubygems.org"
 
 gem "jekyll"
+gem "jekyll-autoprefixer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,10 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    autoprefixer-rails (6.3.7)
+      execjs
     colorator (1.1.0)
+    execjs (2.7.0)
     ffi (1.9.14)
     forwardable-extended (2.6.0)
     jekyll (3.3.1)
@@ -17,6 +20,8 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-autoprefixer (1.0.1)
+      autoprefixer-rails (~> 6.3.6)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -42,6 +47,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-autoprefixer
 
 BUNDLED WITH
    1.13.6

--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,5 @@ collections:
     permalink: /:path/
 sass:
   style: compressed
+gems:
+- jekyll-autoprefixer


### PR DESCRIPTION
this will make sure that for example flexbox syntax will work up to IE9 or something like that.
see https://github.com/vwochnik/jekyll-autoprefixer for more info

no further setup needed