### PR TITLE
use black for text in the charts

### DIFF
--- a/_sass/components/results.scss
+++ b/_sass/components/results.scss
@@ -34,7 +34,7 @@
 	}
 
 	text {
-		fill: $c-background;
+		fill: black;
 	}
 
 	.axisHorizontal path{


### PR DESCRIPTION
Also not ideal, but at least you can actually see it

before|after
---|---
 <img width="220" alt="screen shot 2016-12-20 at 21 08 49" src="https://cloud.githubusercontent.com/assets/6270048/21366094/9f194b86-c6f8-11e6-9ff0-e5d453ab9593.png">|<img width="177" alt="screen shot 2016-12-20 at 21 09 14" src="https://cloud.githubusercontent.com/assets/6270048/21366093/9efd0854-c6f8-11e6-8122-8919ac7e677c.png">
