### PR TITLE
no input shine on ios

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -29,6 +29,12 @@ a {
 	}
 }
 
+// iOS bug
+input {
+	appearance: none;
+	background-color: white;
+}
+
 code {
 	font-family: $f-monospace;
 }

--- a/_sass/components/button.scss
+++ b/_sass/components/button.scss
@@ -6,6 +6,7 @@ button, input[type=submit] {
 	color: $c-header;
 	padding: $s-small $s-medium;
 	transition: background-color .2s;
+	appearance: none; // iOS bug
 
 	&:active {
 		background-color: $c-accent-light;


### PR DESCRIPTION
It annoyed me.

(there's no complete "vote" component with the input button, so you won't see the difference here, not on simulators either, only on physical devices if you switch out the css with this pr's css)